### PR TITLE
fix: automatically match index in WebUI

### DIFF
--- a/infer/modules/vc/utils.py
+++ b/infer/modules/vc/utils.py
@@ -1,12 +1,15 @@
 import os
 
 from fairseq import checkpoint_utils
+from pathlib import Path
 
 
 def get_index_path_from_model(sid):
+    s = Path(sid)
+    s = s.stem.rsplit("_e")[0]
     return next(
         (
-            f
+            f.replace('/','\\')
             for f in [
                 os.path.join(root, name)
                 for root, _, files in os.walk(os.getenv("index_root"), topdown=False)
@@ -18,7 +21,7 @@ def get_index_path_from_model(sid):
                 for name in files
                 if name.endswith(".index") and "trained" not in name
             ]
-            if sid.rsplit("_e")[0] in f or os.path.splitext(sid)[0] in f
+            if s in f
         ),
         "",
     )

--- a/infer/modules/vc/utils.py
+++ b/infer/modules/vc/utils.py
@@ -1,12 +1,16 @@
 import os
 
 from fairseq import checkpoint_utils
+from pathlib import Path
 
 
 def get_index_path_from_model(sid):
+    s = Path(sid)
+    s = s.stem.rsplit("_e")[0]
+    print(s)
     return next(
         (
-            f
+            f.replace('/','\\')
             for f in [
                 os.path.join(root, name)
                 for root, _, files in os.walk(os.getenv("index_root"), topdown=False)
@@ -18,7 +22,7 @@ def get_index_path_from_model(sid):
                 for name in files
                 if name.endswith(".index") and "trained" not in name
             ]
-            if sid.rsplit("_e")[0] in f or os.path.splitext(sid)[0] in f
+            if s in f
         ),
         "",
     )

--- a/infer/modules/vc/utils.py
+++ b/infer/modules/vc/utils.py
@@ -12,8 +12,13 @@ def get_index_path_from_model(sid):
                 for root, _, files in os.walk(os.getenv("index_root"), topdown=False)
                 for name in files
                 if name.endswith(".index") and "trained" not in name
+            ]+[
+                os.path.join(root, name)
+                for root, _, files in os.walk(os.getenv("outside_index_root"), topdown=False)
+                for name in files
+                if name.endswith(".index") and "trained" not in name
             ]
-            if sid.split(".")[0] in f
+            if sid.rsplit("_e")[0] in f or os.path.splitext(sid)[0] in f
         ),
         "",
     )


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

 Before fix, when choosing a weight and its filename ended with like "_e11 _s4514", it cannot auto-match its index file. And it will never search indice from outside_index_root.

# PR type

- Bug fix

# Description

- 
